### PR TITLE
Adding php-pecl-zip for c5-php51

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:centos5
 
 MAINTAINER Manuel Vacelet, manuel.vacelet@enalean.com
+MAINTAINER Yannis ROSSETTO <yannis.rossetto@enalean.com>
 
 # EPEL
 RUN rpm -i http://fr2.rpmfind.net/linux/epel/5/i386/epel-release-5-4.noarch.rpm
@@ -29,6 +30,7 @@ RUN yum -y install php \
     subversion \
     bzip2 \
     php-pecl-json \
+    php-pecl-zip \
     subversion && \
     yum clean all
 


### PR DESCRIPTION
We have a dependency with php ZipArchive class.
However, this class is only avaible in php since php 5.2.

In order to have it for our php 5.1 instances, we have to install the
php-pecl-zip package from RepoForge.
