### PR TITLE
Add php-sodium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yum install -y epel-release centos-release-scl && \
     php72-php-mbstring \
     php72-php-imap \
     php72-php-intl \
+    php72-php-sodium \
     php72-php-pecl-zip \
     php72-php-pecl-xdebug \
     php72-php-pecl-redis \


### PR DESCRIPTION
[request #12278](https://tuleap.net/plugins/tracker/?aid=12278): Tuleap cryptography API should work out of box on PHP 7.2 with php-sodium.


Must be merged after [gerrit #12630](https://gerrit.tuleap.net/#/c/tuleap/+/12630/).